### PR TITLE
WIP: Preserve PTS information

### DIFF
--- a/lib/membrane_aac_fdk_plugin/decoder.ex
+++ b/lib/membrane_aac_fdk_plugin/decoder.ex
@@ -47,6 +47,11 @@ defmodule Membrane.AAC.FDK.Decoder do
   # since they should stay consistent for the whole stream.
   # 4. In case an unhandled error is returned during this flow, returns error message.
   @impl true
+  def handle_process(:input, %Buffer{pts: nil} = buffer, ctx, %{next_pts: nil} = state) do
+    # Start from 0 in case there are no pts at all.
+    handle_process(:input, buffer, ctx, %{state | next_pts: 0})
+  end
+
   def handle_process(:input, %Buffer{pts: pts} = buffer, ctx, %{next_pts: nil} = state) do
     handle_process(:input, buffer, ctx, %{state | next_pts: pts})
   end

--- a/lib/membrane_aac_fdk_plugin/decoder.ex
+++ b/lib/membrane_aac_fdk_plugin/decoder.ex
@@ -69,7 +69,7 @@ defmodule Membrane.AAC.FDK.Decoder do
     {%Buffer{buffer | pts: next_pts}, next_pts + RawAudio.bytes_to_time(byte_size(payload), format)}
   end
 
-  defp fill_decoder(%Buffer{payload: payload, pts: pts, dts: dts}, %{native: native}) do
+  defp fill_decoder(%Buffer{payload: payload, pts: pts}, %{native: native}) do
     :ok = Native.fill!(payload, native)
   end
 

--- a/lib/membrane_aac_fdk_plugin/decoder.ex
+++ b/lib/membrane_aac_fdk_plugin/decoder.ex
@@ -69,7 +69,7 @@ defmodule Membrane.AAC.FDK.Decoder do
     {%Buffer{buffer | pts: next_pts}, next_pts + RawAudio.bytes_to_time(byte_size(payload), format)}
   end
 
-  defp fill_decoder(%Buffer{payload: payload, pts: pts}, %{native: native}) do
+  defp fill_decoder(%Buffer{payload: payload}, %{native: native}) do
     :ok = Native.fill!(payload, native)
   end
 

--- a/lib/membrane_aac_fdk_plugin/decoder.ex
+++ b/lib/membrane_aac_fdk_plugin/decoder.ex
@@ -53,8 +53,11 @@ defmodule Membrane.AAC.FDK.Decoder do
 
   def handle_process(:input, buffer, _ctx, %{output_format: format, next_pts: pts} = state) do
     fill_decoder(buffer, state)
-    buffer = decode_buffer(buffer, state)
-    {buffer, next_pts} = update_pts(buffer, format, pts)
+    {buffer, next_pts} =
+      buffer
+      |> decode_buffer(state)
+      |> update_pts(format, pts)
+
     {[buffer: {:output, buffer}], %{state | next_pts: next_pts}}
   end
 


### PR DESCRIPTION
Hi there! We've noticed that the Decoder is not preserving Buffer pts information. We've a first draft for solving the problem
- Use the pts information of the first buffer to obtain a starting point
- For each frame decoded, compute its duration. Use that value to update the base pts
- Update the buffer pts field

Waiting for your feedback. (BTW, KIM is back on Membrane 😉💯)