### PR TITLE
Set pts at the end of stream (acc_fdk)

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ The package can be installed by adding `membrane_aac_fdk_plugin` to your list of
 ```elixir
 def deps do
   [
-	{:membrane_aac_fdk_plugin, "~> 0.18.5"}
+	{:membrane_aac_fdk_plugin, "~> 0.18.6"}
   ]
 end
 ```

--- a/lib/membrane_aac_fdk_plugin/encoder.ex
+++ b/lib/membrane_aac_fdk_plugin/encoder.ex
@@ -182,7 +182,9 @@ defmodule Membrane.AAC.FDK.Encoder do
     actions = [end_of_stream: :output]
 
     with {:ok, encoded_frame} <- Native.encode_frame(<<>>, native) do
-      buffer_actions = [buffer: {:output, %Buffer{payload: encoded_frame}}]
+      buffer_actions = [
+        buffer: {:output, %Buffer{payload: encoded_frame, pts: state.current_pts}}
+      ]
 
       {buffer_actions ++ actions, state}
     else

--- a/mix.exs
+++ b/mix.exs
@@ -1,7 +1,7 @@
 defmodule Membrane.AAC.FDK.Plugin.MixProject do
   use Mix.Project
 
-  @version "0.18.5"
+  @version "0.18.6"
   @github_url "https://github.com/membraneframework/membrane_aac_fdk_plugin"
 
   def project do


### PR DESCRIPTION
PTS value is bumped every time encode_buffer is run. 
After last encode_buffer in state there is a PTS value ready for the next buffer, that means we simply assign pts from state to the buffer that's returned from end_of_stream.