### PR TITLE
resolve issue in example -  README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ defmodule AAC.Pipeline do
       })
       |> child(:sink, Membrane.PortAudio.Sink)
 
-    {[spec: structure, playback: :playing], %{}}
+    {[spec: structure], %{}}
   end
 end
 

--- a/README.md
+++ b/README.md
@@ -105,7 +105,6 @@ defmodule AAC.Pipeline do
   end
 end
 
-{:ok, _pipeline_supervisor, _pipeline} = AAC.Pipeline.start_link([])
 {:ok, _pipeline_supervisor, _pipeline} = Membrane.Pipeline.start_link(AAC.Pipeline, "")
 ```
 

--- a/README.md
+++ b/README.md
@@ -106,6 +106,7 @@ defmodule AAC.Pipeline do
 end
 
 {:ok, _pipeline_supervisor, _pipeline} = AAC.Pipeline.start_link([])
+{:ok, _pipeline_supervisor, _pipeline} = Membrane.Pipeline.start_link(AAC.Pipeline, "")
 ```
 
 ## Copyright and License

--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ defmodule AAC.Pipeline do
   end
 end
 
-{:ok, _pipeline_supervisor, _pipeline} = Membrane.Pipeline.start_link(AAC.Pipeline, "")
+{:ok, _pipeline_supervisor, _pipeline} = Membrane.Pipeline.start_link(AAC.Pipeline, [])
 ```
 
 ## Copyright and License


### PR DESCRIPTION
Hello! 

Seems like README's "Decoder" example is not working as-is.
Error message:
```
Evaluation process terminated - an exception was raised:
    ** (Membrane.ActionError) Error while handling action {:playback, :playing}
We looked everywhere, but couldn't find out what this action is supposed to do.
Make sure it's correct and valid for the component, its playback, callback or
other possible circumstances. See the docs for Membrane.Pipeline.Action to check
which actions are supported and when you can return them.


        (membrane_core 1.0.1) lib/membrane/core/pipeline/action_handler.ex:104: Membrane.Core.Pipeline.ActionHandler.handle_action/4
        (membrane_core 1.0.1) lib/membrane/core/callback_handler.ex:197: anonymous fn/5 in Membrane.Core.CallbackHandler.handle_callback_result/5
        (elixir 1.15.7) lib/enum.ex:2510: Enum."-reduce/3-lists^foldl/2-0-"/3
        (membrane_core 1.0.1) lib/membrane/core/callback_handler.ex:195: Membrane.Core.CallbackHandler.handle_callback_result/5
        (membrane_core 1.0.1) lib/membrane/core/pipeline.ex:64: Membrane.Core.Pipeline.init/1
        (stdlib 5.1.1) gen_server.erl:962: :gen_server.init_it/2
        (stdlib 5.1.1) gen_server.erl:917: :gen_server.init_it/6
        (stdlib 5.1.1) proc_lib.erl:241: :proc_lib.init_p_do_apply/3
```


For new developers it might take a bit of time to figure out that the example works without `playback: :playing` in `handle_init/2` response. 
Tested both in Livebook and IEx

Short demo "Before/after": https://youtu.be/m3ie7b7ccQc