### PR TITLE
Use dirty CPU NIFs. Bump to v0.18.12

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ The package can be installed by adding `membrane_aac_fdk_plugin` to your list of
 ```elixir
 def deps do
   [
-    {:membrane_aac_fdk_plugin, "~> 0.18.9"}
+    {:membrane_aac_fdk_plugin, "~> 0.18.10"}
   ]
 end
 ```

--- a/c_src/membrane_aac_fdk_plugin/decoder.spec.exs
+++ b/c_src/membrane_aac_fdk_plugin/decoder.spec.exs
@@ -14,3 +14,5 @@ spec fill(payload, state) :: (:ok :: label)
 spec decode_frame(payload, state) :: {:ok :: label, payload}
   | {:error :: label, :not_enough_bits :: label}
   | {:error :: label, :unknown :: label}
+
+dirty :cpu, [:create, :get_metadata, :fill, :decode_frame]

--- a/c_src/membrane_aac_fdk_plugin/encoder.spec.exs
+++ b/c_src/membrane_aac_fdk_plugin/encoder.spec.exs
@@ -14,3 +14,5 @@ spec create(
 spec encode_frame(payload, state) :: {:ok :: label, payload}
   | {:error :: label, reason :: atom}
   | {:error :: label, :no_data :: label}
+
+dirty :cpu, [:create, :encode_frame]

--- a/mix.exs
+++ b/mix.exs
@@ -1,7 +1,7 @@
 defmodule Membrane.AAC.FDK.Plugin.MixProject do
   use Mix.Project
 
-  @version "0.18.9"
+  @version "0.18.10"
   @github_url "https://github.com/membraneframework/membrane_aac_fdk_plugin"
 
   def project do


### PR DESCRIPTION
This PR:
* forces usage of dirty CPU NIFs for all the functions delivered by native encoder and decoder
* bumps version to v0.18.12